### PR TITLE
Fix worker_processes call if environment var isn't set

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,6 +1,6 @@
 # config/unicorn.rb
 
-worker_processes Integer(ENV["UNICORN_WORKERS"]) || 3
+worker_processes Integer(ENV["UNICORN_WORKERS"] || 3)
 timeout 30
 preload_app true
 


### PR DESCRIPTION
worker_processes was erroring if the UNICORN_WORKERS environment variable wasn't set. Just a misplaced right parenthesis
